### PR TITLE
fix incorrect error reporting on mongo auth fail (no test case)

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -371,7 +371,7 @@ Collection.prototype.insert = function (data, opts, fn) {
   promise.query = data;
   this.col.insert(data, opts, function (err, docs) {
     immediately(function () {
-      var res = docs.ops;
+      var res = docs && docs.ops;
       if (!err && docs && !arrayInsert) {
         res = docs.ops[0];
       }


### PR DESCRIPTION
This bug happens when I insert into a database with authentication and provide an incorrect password. The `docs` variable would go `null` and break the promise.
